### PR TITLE
MOD file changes to make model compatible with CoreNEURON

### DIFF
--- a/mechanisms/Gfluct3.mod
+++ b/mechanisms/Gfluct3.mod
@@ -338,8 +338,8 @@ FUNCTION exptrap(loc,x) {
 }
 
 VERBATIM
-#if !NRNBBCORE
 static void bbcore_write(double* x, int* d, int* xx, int *offset, _threadargsproto_) {
+#if !NRNBBCORE
 	/* error if using the legacy normrand */
 	if (!_p_donotuse) {
 		fprintf(stderr, "Gfluct3: cannot use the legacy normrand generator for the random stream.\n");
@@ -361,8 +361,8 @@ static void bbcore_write(double* x, int* d, int* xx, int *offset, _threadargspro
 		/*printf("Gfluct3 bbcore_write %d %d %d\n", di[0], di[1], di[3]);*/
 	}
 	*offset += 3;
-}
 #endif
+}
 
 static void bbcore_read(double* x, int* d, int* xx, int* offset, _threadargsproto_) {
 	assert(!_p_donotuse);

--- a/mechanisms/lca.mod
+++ b/mechanisms/lca.mod
@@ -40,6 +40,7 @@ NEURON {
 	SUFFIX CavLcck
 	USEION ca READ cai, cao, eca WRITE ica VALENCE 2 
         RANGE gmax, cai, ica, eca, g, minf, mtau
+    THREADSAFE
 }
 
 STATE {
@@ -59,6 +60,9 @@ INITIAL {
 	rate(v)
 	m = minf
 	VERBATIM
+    #if NRNBBCORE
+    double * _nt_data = _nt->_data;
+    #endif
 	cai=_ion_cai;
 	ENDVERBATIM
 }

--- a/mechanisms/vecevent.mod
+++ b/mechanisms/vecevent.mod
@@ -61,7 +61,7 @@ ENDVERBATIM
 VERBATIM
 #include <stdint.h>
 #if NRNBBCORE
-#include "coreneuron/nrniv/ivocvect.h"
+#include "coreneuron/utils/ivocvect.hpp"
 #endif
 ENDVERBATIM
 
@@ -107,8 +107,8 @@ ENDVERBATIM
 }
 
 VERBATIM
-#if !NRNBBCORE
 static void bbcore_write(double* dArray, int* iArray, int* doffset, int* ioffset, _threadargsproto_) {
+#if !NRNBBCORE
         uint32_t dsize = 0;
         if (_p_ptr) {
           dsize = (uint32_t)vector_capacity(_p_ptr);
@@ -130,8 +130,8 @@ static void bbcore_write(double* dArray, int* iArray, int* doffset, int* ioffset
         }
         *ioffset += 1;
         *doffset += dsize;
-}
 #endif
+}
 
 static void bbcore_read(double* dArray, int* iArray, int* doffset, int* ioffset, _threadargsproto_) {
         assert(!_p_ptr);


### PR DESCRIPTION
  - new version of coreneuron has different include path for coreneuron/nrniv/ivocvect.h
  - bbcore_write definition should be present for coreneuron as well
  - lca.mod should be marked as THREADSAFE and _nt_data should be
    explicitly declared

Hello @iraikov! Few years ago we worked together to run this model with CoreNEURON. Today I was helping Prannath with [NEURON installation issues](https://github.com/neuronsimulator/nrn/pull/608) and that's when I came across this model on GitHub. I thought I can make small changes to fix compatibility issues with latest CoreNEURON version.