### PR TITLE
Make vecevent.mod and Gfluct3.mod compatible with the upcoming NEURON release (& current master)

### DIFF
--- a/mechanisms/vecevent.mod
+++ b/mechanisms/vecevent.mod
@@ -86,7 +86,7 @@ NET_RECEIVE (w) {
 DESTRUCTOR {
 VERBATIM
 #if !NRNBBCORE
-	void* vv = (void*)(_p_ptr);  
+	IvocVect* vv = (IvocVect*)(_p_ptr);
         if (vv) {
 		hoc_obj_unref(*vector_pobj(vv));
 	}
@@ -96,10 +96,10 @@ ENDVERBATIM
 
 PROCEDURE element() {
 VERBATIM	
-  { void* vv; int i, size; double* px;
+  { IvocVect* vv; int i, size; double* px;
 	i = (int)index;
 	if (i >= 0) {
-		vv = (void*)(_p_ptr);
+		vv = (IvocVect*)(_p_ptr);
 		if (vv) {
 			size = vector_capacity(vv);
 			px = vector_vec(vv);
@@ -121,13 +121,13 @@ PROCEDURE play() {
 VERBATIM
 #if !NRNBBCORE
   {
-	void** pv;
-	void* ptmp = NULL;
+	IvocVect** pv;
+	IvocVect* ptmp = NULL;
 	if (ifarg(1)) {
 		ptmp = vector_arg(1);
 		hoc_obj_ref(*vector_pobj(ptmp));
 	}
-	pv = (void**)(&_p_ptr);
+	pv = (IvocVect**)(&_p_ptr);
 	if (*pv) {
 		hoc_obj_unref(*vector_pobj(*pv));
 	}
@@ -143,10 +143,10 @@ static void bbcore_write(double* xarray, int* iarray, int* xoffset, int* ioffset
   double *xa, *dv;
   dsize = 0;
   if (_p_ptr) {
-    dsize = vector_capacity(_p_ptr);
+    dsize = vector_capacity((IvocVect*)_p_ptr);
   }
   if (iarray) {
-    void* vec = _p_ptr;
+    IvocVect* vec = (IvocVect*)_p_ptr;
     ia = iarray + *ioffset;
     xa = xarray + *xoffset;
     ia[0] = dsize;
@@ -168,11 +168,15 @@ static void bbcore_read(double* xarray, int* iarray, int* xoffset, int* ioffset,
   xa = xarray + *xoffset;
   ia = iarray + *ioffset;
   dsize = ia[0];
-  if (!_p_ptr) {
-    _p_ptr = vector_new1(dsize);
+
+  IvocVect* pv = (IvocVect*)_p_ptr;
+  if (!pv) {
+    pv = vector_new1(dsize);
   }
-  assert(dsize == vector_capacity(_p_ptr));
-  dv = vector_vec(_p_ptr);
+  assert(dsize == vector_capacity(pv));
+  _p_ptr = (double*)pv;
+
+  dv = vector_vec(pv);
   for (i = 0; i < dsize; ++i) {
     dv[i] = xa[i];
   }

--- a/unused/Gfluct3.mod
+++ b/unused/Gfluct3.mod
@@ -100,7 +100,6 @@ NEURON {
 	POINT_PROCESS Gfluct3
 	RANGE h, on, g_e, g_i, E_e, E_i, g_e0, g_i0, g_e1, g_i1
 	RANGE std_e, std_i, tau_e, tau_i, D_e, D_i
-	RANGE new_seed
 	NONSPECIFIC_CURRENT i
 	THREADSAFE
 	BBCOREPOINTER donotuse


### PR DESCRIPTION
* MOD file translation is being changed from C to C++ and requires certain changes for type safety. These are all syntax changes. See https://nrn.readthedocs.io/en/latest/guide/porting_mechanisms_to_cpp.html
* Gfluct3.mod declares a variable of the same name as RANGE variable. This will be an error in the upcoming release. See neuronsimulator/nrn/pull/1992

This shouldn't break anything with 